### PR TITLE
refactor: Use `rootFunc` instead of custom pseudo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.6.0",
             "license": "BSD-2-Clause",
             "dependencies": {
+                "boolbase": "^1.0.0",
                 "css-select": "^5.1.0",
                 "css-what": "^6.1.0",
                 "domelementtype": "^2.3.0",
@@ -16,6 +17,7 @@
                 "domutils": "^3.0.1"
             },
             "devDependencies": {
+                "@types/boolbase": "^1.0.1",
                 "@types/jest": "^27.4.1",
                 "@types/node": "^17.0.29",
                 "@typescript-eslint/eslint-plugin": "^5.21.0",
@@ -1079,6 +1081,12 @@
             "dependencies": {
                 "@babel/types": "^7.3.0"
             }
+        },
+        "node_modules/@types/boolbase": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@types/boolbase/-/boolbase-1.0.1.tgz",
+            "integrity": "sha512-ulr2ZqSiEEwtehELPYJjIleXEebz101NzmGn0CWg19+Ud8OoEnJOUJRnfo5F6KUV+x+Pngz1uaesjhINx6mwlQ==",
+            "dev": true
         },
         "node_modules/@types/graceful-fs": {
             "version": "4.1.5",
@@ -6072,6 +6080,12 @@
             "requires": {
                 "@babel/types": "^7.3.0"
             }
+        },
+        "@types/boolbase": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@types/boolbase/-/boolbase-1.0.1.tgz",
+            "integrity": "sha512-ulr2ZqSiEEwtehELPYJjIleXEebz101NzmGn0CWg19+Ud8OoEnJOUJRnfo5F6KUV+x+Pngz1uaesjhINx6mwlQ==",
+            "dev": true
         },
         "@types/graceful-fs": {
             "version": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "prepare": "npm run build"
     },
     "dependencies": {
+        "boolbase": "^1.0.0",
         "css-select": "^5.1.0",
         "css-what": "^6.1.0",
         "domelementtype": "^2.3.0",
@@ -41,6 +42,7 @@
         "domutils": "^3.0.1"
     },
     "devDependencies": {
+        "@types/boolbase": "^1.0.1",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.29",
         "@typescript-eslint/eslint-plugin": "^5.21.0",


### PR DESCRIPTION
Same effect, without the risk of a collision.